### PR TITLE
Supports scheduler event

### DIFF
--- a/src/Scheduler/SchedulerEvent.php
+++ b/src/Scheduler/SchedulerEvent.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Dew\Core\Scheduler;
+
+use Dew\Core\Event;
+
+class SchedulerEvent extends Event
+{
+    /**
+     * Determine if the given payload belongs to the event.
+     *
+     * @param  array<string, mixed>  $event
+     */
+    public static function is(array $event): bool
+    {
+        return isset($event['source']) && $event['source'] === 'dew.scheduler';
+    }
+}

--- a/src/Scheduler/SchedulerHandler.php
+++ b/src/Scheduler/SchedulerHandler.php
@@ -27,7 +27,7 @@ class SchedulerHandler extends EventHandler
     public function runScheduled(): void
     {
         Process::fromShellCommandline(
-            'php artisan scheduler:run', $this->events->context()->codePath()
+            'php artisan schedule:run', $this->events->context()->codePath()
         )->run(function ($type, $buffer): void {
             echo $buffer;
         });

--- a/src/Scheduler/SchedulerHandler.php
+++ b/src/Scheduler/SchedulerHandler.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Dew\Core\Scheduler;
+
+use Dew\Core\EventHandler;
+use Nyholm\Psr7\Response;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Process\Process;
+
+class SchedulerHandler extends EventHandler
+{
+    /**
+     * Handle the given event.
+     *
+     * @param  \Dew\Core\Contracts\FunctionComputeEvent  $event
+     */
+    public function handle($event): ResponseInterface
+    {
+        $this->runScheduled();
+
+        return new Response;
+    }
+
+    /**
+     * Run scheduled commands.
+     */
+    public function runScheduled(): void
+    {
+        Process::fromShellCommandline(
+            'php artisan scheduler:run', $this->events->context()->codePath()
+        )->run();
+    }
+}

--- a/src/Scheduler/SchedulerHandler.php
+++ b/src/Scheduler/SchedulerHandler.php
@@ -28,6 +28,8 @@ class SchedulerHandler extends EventHandler
     {
         Process::fromShellCommandline(
             'php artisan scheduler:run', $this->events->context()->codePath()
-        )->run();
+        )->run(function ($type, $buffer): void {
+            echo $buffer;
+        });
     }
 }

--- a/stubs/consoleHandler.php
+++ b/stubs/consoleHandler.php
@@ -5,10 +5,13 @@ use Dew\Core\Cli\CliHandler;
 use Dew\Core\EventManager;
 use Dew\Core\FunctionCompute;
 use Dew\Core\RoadRunner;
+use Dew\Core\Scheduler\SchedulerEvent;
+use Dew\Core\Scheduler\SchedulerHandler;
 
 $events = new EventManager(RoadRunner::createFromGlobal());
 
 $events->register(CliEvent::class, CliHandler::class);
+$events->register(SchedulerEvent::class, SchedulerHandler::class);
 
 $events->contextUsing(FunctionCompute::createFromEnvironment());
 

--- a/tests/SchedulerEventTest.php
+++ b/tests/SchedulerEventTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Dew\Core\Tests;
+
+use Dew\Core\Scheduler\SchedulerEvent;
+use PHPUnit\Framework\TestCase;
+
+class SchedulerEventTest extends TestCase
+{
+    public function test_event_validation()
+    {
+        $this->assertTrue(SchedulerEvent::is(['source' => 'dew.scheduler']));
+        $this->assertFalse(SchedulerEvent::is([]));
+    }
+}

--- a/tests/SchedulerHandlerTest.php
+++ b/tests/SchedulerHandlerTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Dew\Core\Tests;
+
+use Dew\Core\Scheduler\SchedulerEvent;
+use Dew\Core\Scheduler\SchedulerHandler;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+
+class SchedulerHandlerTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+    }
+
+    public function test_response_is_empty()
+    {
+        $handler = Mockery::mock(SchedulerHandler::class)->makePartial();
+        $handler->expects()->runScheduled();
+
+        $response = $handler->handle(new SchedulerEvent([]));
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+}


### PR DESCRIPTION
The scheduler handler executes `php artisan schedule:run` behind the scenes which allows developers to automate tasks such as sending emails, generating repots and backing up data.