### PR TITLE
Supports handling MNS queue job

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "symfony/process": "^6.3",
         "hollodotme/fast-cgi-client": "^3.1",
         "illuminate/support": "^10.13",
-        "illuminate/queue": "^10.0"
+        "illuminate/queue": "^10.0",
+        "dew-serverless/laravel-mns-driver": "^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.0",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "nyholm/psr7": "^1.8",
         "symfony/process": "^6.3",
         "hollodotme/fast-cgi-client": "^3.1",
-        "illuminate/support": "^10.13"
+        "illuminate/support": "^10.13",
+        "illuminate/queue": "^10.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.0",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "hollodotme/fast-cgi-client": "^3.1",
         "illuminate/support": "^10.13",
         "illuminate/queue": "^10.0",
-        "dew-serverless/laravel-mns-driver": "^2.0"
+        "dew-serverless/laravel-mns-driver": "^2.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.0",

--- a/src/Contracts/ProvidesDewContext.php
+++ b/src/Contracts/ProvidesDewContext.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Dew\Core\Contracts;
+
+interface ProvidesDewContext
+{
+    /**
+     * The MNS queue name.
+     */
+    public function mnsQueue(): ?string;
+}

--- a/src/FunctionCompute.php
+++ b/src/FunctionCompute.php
@@ -4,8 +4,10 @@ namespace Dew\Core;
 
 use Darabonba\OpenApi\Models\Config;
 use Dew\Core\Contracts\ProvidesContext;
+use Dew\Core\Contracts\ProvidesDewContext;
+use RuntimeException;
 
-class FunctionCompute implements ProvidesContext
+class FunctionCompute implements ProvidesContext, ProvidesDewContext
 {
     /**
      * New Function Compute context.
@@ -129,6 +131,14 @@ class FunctionCompute implements ProvidesContext
     public function codePath(): string
     {
         return $this->context['FC_FUNC_CODE_PATH'];
+    }
+
+    /**
+     * The MNS queue name.
+     */
+    public function mnsQueue(): ?string
+    {
+        return $this->context['DEW_MNS_QUEUE'] ?? null;
     }
 
     /**

--- a/src/Queue/MnsEvent.php
+++ b/src/Queue/MnsEvent.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Dew\Core\Queue;
+
+use Dew\Core\Event;
+
+class MnsEvent extends Event
+{
+    /**
+     * Determine if the given payload belongs to the event.
+     *
+     * @param  array<string, mixed>  $event
+     */
+    public static function is(array $event): bool
+    {
+        return isset($event['source']) && $event['source'] === 'dew.queue';
+    }
+
+    /**
+     * The request ID.
+     */
+    public function requestId(): string
+    {
+        return $this->event['data']['requestId'];
+    }
+
+    /**
+     * The MNS message ID.
+     */
+    public function messageId(): string
+    {
+        return $this->event['data']['messageId'];
+    }
+
+    /**
+     * The MNS message body.
+     *
+     * @return array<string, mixed>
+     */
+    public function messageBody(): array
+    {
+        return $this->event['data']['messageBody'];
+    }
+}

--- a/src/Queue/MnsHandler.php
+++ b/src/Queue/MnsHandler.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Dew\Core\Queue;
+
+use Dew\Core\EventHandler;
+use Dew\MnsDriver\MnsQueue;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Queue\WorkerOptions;
+use Nyholm\Psr7\Response;
+use Psr\Http\Message\ResponseInterface;
+use RuntimeException;
+
+class MnsHandler extends EventHandler
+{
+    /**
+     * The Laravel application.
+     */
+    protected Application $laravel;
+
+    /**
+     * The MNS queue worker.
+     */
+    protected MnsWorker $worker;
+
+    /**
+     * Handle the given event.
+     *
+     * @param  \Dew\Core\Queue\MnsEvent  $event
+     */
+    public function handle($event): ResponseInterface
+    {
+        $queue = $this->laravel()->make('queue')->connection();
+
+        if (! $queue instanceof MnsQueue) {
+            throw new RuntimeException('The queue must be a MNS queue.');
+        }
+
+        $this->worker()->runMnsJob(
+            $this->toJob($event, $queue),
+            $queue->getConnectionName(),
+            $this->options(['name' => $queue->getConnectionName()])
+        );
+
+        return new Response;
+    }
+
+    /**
+     * The MNS queue worker.
+     */
+    public function worker(): MnsWorker
+    {
+        return $this->worker ??= $this->makeWorker();
+    }
+
+    /**
+     * Set MNS queue worker.
+     */
+    public function workerUsing(MnsWorker $worker): self
+    {
+        $this->worker = $worker;
+
+        return $this;
+    }
+
+    /**
+     * Make a MNS queue worker.
+     */
+    protected function makeWorker(): MnsWorker
+    {
+        return $this->laravel()->make(MnsWorker::class, [
+            'isDownForMaintenance' => fn () => $this->laravel()->isDownForMaintenance(),
+        ]);
+    }
+
+    /**
+     * Build MNS job from the given event.
+     */
+    public function toJob(MnsEvent $event, MnsQueue $queue): MnsJob
+    {
+        return new MnsJob(
+            $this->laravel()->make(Container::class),
+            $queue->getMns(), $event,
+            $queue->getConnectionName(), $queue->getQueue()
+        );
+    }
+
+    /**
+     * The worker options.
+     *
+     * @param  array<string, mixed>  $options
+     */
+    public function options(array $options = []): WorkerOptions
+    {
+        $options = new WorkerOptions(
+            timeout: 60, backoff: 0, sleep: 3, rest: 0,
+            memory: 128, force: false, stopWhenEmpty: false,
+            maxTries: 3, maxJobs: 0, maxTime: 0
+        );
+
+        foreach ($options as $name => $value) {
+            if (property_exists($options, $name)) {
+                $options->$name = $value;
+            }
+        }
+
+        return $options;
+    }
+
+    /**
+     * The Laravel application.
+     */
+    public function laravel(): Application
+    {
+        return $this->laravel ??= $this->makeLaravel();
+    }
+
+    /**
+     * Set Laravel application.
+     */
+    public function laravelUsing(Application $laravel): self
+    {
+        $this->laravel = $laravel;
+
+        return $this;
+    }
+
+    /**
+     * Make and bootstrap Laravel application.
+     */
+    protected function makeLaravel(): Application
+    {
+        $app = require $this->events()->context()->codePath().'/bootstrap/app.php';
+
+        return tap($app, function (Application $app) {
+            $kernel = $app->make(\Illuminate\Contracts\Console\Kernel::class);
+
+            $kernel->bootstrap();
+        });
+    }
+}

--- a/src/Queue/MnsJob.php
+++ b/src/Queue/MnsJob.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Dew\Core\Queue;
+
+use Dew\Mns\Versions\V20150606\Queue;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Queue\Job as JobContract;
+use Illuminate\Queue\Jobs\Job;
+
+class MnsJob extends Job implements JobContract
+{
+    /**
+     * Create a new job instance.
+     *
+     * @param  \Dew\Mns\Versions\V20150606\Queue  $mns
+     */
+    public function __construct(
+        Container $container,
+        protected $mns,
+        protected MnsEvent $job,
+        string $connectionName,
+        string $queue
+    ) {
+        $this->container = $container;
+        $this->connectionName = $connectionName;
+        $this->queue = $queue;
+    }
+
+    /**
+     * Get the job identifier.
+     *
+     * @return string
+     */
+    public function getJobId()
+    {
+        return $this->job->messageId();
+    }
+
+    /**
+     * Get the raw body of the job.
+     *
+     * @return string
+     */
+    public function getRawBody()
+    {
+        return json_encode($this->job->messageBody());
+    }
+
+    /**
+     * Release the job back into the queue after (n) seconds.
+     *
+     * @param  int  $delay
+     * @return void
+     */
+    public function release($delay = 0)
+    {
+        parent::release($delay);
+
+        $message = tap($this->payload(), function (&$job) {
+            $job['attempts'] = $this->attempts();
+        });
+
+        // The returned payload doesn't contain a receipt handle. Instead of
+        // changing message visibility, the only option is to consume the
+        // current message and send it again to the queue with a delay.
+        $this->mns->sendMessage($this->queue, [
+            'MessageBody' => json_encode($message),
+            'DelaySeconds' => $delay,
+        ]);
+    }
+
+    /**
+     * Get the number of times the job has been attempted.
+     *
+     * @return int
+     */
+    public function attempts()
+    {
+        return ($this->payload()['attempts'] ?? 0) + 1;
+    }
+
+    /**
+     * The underlying MNS queue instance.
+     */
+    public function getMns(): Queue
+    {
+        return $this->queue;
+    }
+
+    /**
+     * The underlying MNS job.
+     *
+     * @return array<string, mixed>
+     */
+    public function getMnsJob(): MnsEvent
+    {
+        return $this->job;
+    }
+}

--- a/src/Queue/MnsWorker.php
+++ b/src/Queue/MnsWorker.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Dew\Core\Queue;
+
+use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Queue\Factory;
+use Illuminate\Queue\Worker;
+use Illuminate\Queue\WorkerOptions;
+use Throwable;
+
+class MnsWorker
+{
+    /**
+     * The queue worker.
+     */
+    protected Worker $worker;
+
+    /**
+     * Create a new MNS queue worker.
+     *
+     * @param  callable  $isDownForMaintenance
+     */
+    public function __construct(
+        protected Factory $manager,
+        protected Dispatcher $events,
+        protected ExceptionHandler $exceptions,
+        protected $isDownForMaintenance
+    ) {
+        $this->worker = new Worker(
+            $this->manager, $this->events, $this->exceptions,
+            $this->isDownForMaintenance
+        );
+    }
+
+    /**
+     * Process the MNS job.
+     */
+    public function runMnsJob(MnsJob $job, string $connectionName, WorkerOptions $options): void
+    {
+        try {
+            $this->worker->process($connectionName, $job, $options);
+        } catch (Throwable $e) {
+            $this->exceptions->report($e);
+        }
+    }
+
+    /**
+     * The queue worker.
+     */
+    public function getWorker(): Worker
+    {
+        return $this->worker;
+    }
+}

--- a/src/Support/DewCoreServiceProvider.php
+++ b/src/Support/DewCoreServiceProvider.php
@@ -52,7 +52,7 @@ class DewCoreServiceProvider extends ServiceProvider
      */
     protected function configureQueueConnection(FunctionCompute $context): void
     {
-        $this->app['config']['queue.dew'] = [
+        $this->app['config']['queue.connections.dew'] = [
             'driver' => 'mns',
             'key' => $context->accessKeyId(),
             'secret' => $context->accessKeySecret(),

--- a/src/Support/DewCoreServiceProvider.php
+++ b/src/Support/DewCoreServiceProvider.php
@@ -57,7 +57,7 @@ class DewCoreServiceProvider extends ServiceProvider
             'key' => $context->accessKeyId(),
             'secret' => $context->accessKeySecret(),
             'token' => $context->securityToken(),
-            'endpoint' => sprintf('https://%s.mns.%s-internal.aliyuncs.com',
+            'endpoint' => sprintf('http://%s.mns.%s-internal.aliyuncs.com',
                 $context->accountId(), $context->region()
             ),
             'queue' => $context->mnsQueue(),

--- a/stubs/consoleHandler.php
+++ b/stubs/consoleHandler.php
@@ -4,6 +4,8 @@ use Dew\Core\Cli\CliEvent;
 use Dew\Core\Cli\CliHandler;
 use Dew\Core\EventManager;
 use Dew\Core\FunctionCompute;
+use Dew\Core\Queue\MnsEvent;
+use Dew\Core\Queue\MnsHandler;
 use Dew\Core\RoadRunner;
 use Dew\Core\Scheduler\SchedulerEvent;
 use Dew\Core\Scheduler\SchedulerHandler;
@@ -12,6 +14,7 @@ $events = new EventManager(RoadRunner::createFromGlobal());
 
 $events->register(CliEvent::class, CliHandler::class);
 $events->register(SchedulerEvent::class, SchedulerHandler::class);
+$events->register(MnsEvent::class, MnsHandler::class);
 
 $events->contextUsing(FunctionCompute::createFromEnvironment());
 

--- a/tests/QueueMnsEventTest.php
+++ b/tests/QueueMnsEventTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Dew\Core\Tests;
+
+use Dew\Core\Queue\MnsEvent;
+use PHPUnit\Framework\TestCase;
+
+class QueueMnsEventTest extends TestCase
+{
+    protected string $mockedMessageId;
+
+    protected array $mockedMessageBody;
+
+    protected string $mockedRequestId;
+
+    protected MnsEvent $mockedEvent;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->mockedMessageId = '4D309C5EAEC97F852A1C2C40FCF32EA7';
+        $this->mockedMessageBody = ['job' => 'greeting', 'data' => ['greeting' => 'Hello world!']];
+        $this->mockedRequestId = '654C78B8384138799B6F5ED9';
+        $this->mockedEvent = new MnsEvent([
+            'source' => 'dew.queue',
+            'data' => [
+                'messageId' => $this->mockedMessageId,
+                'messageBody' => $this->mockedMessageBody,
+                'requestId' => $this->mockedRequestId,
+            ],
+        ]);
+    }
+
+    public function test_event_validation()
+    {
+        $this->assertTrue(MnsEvent::is(['source' => 'dew.queue']));
+        $this->assertFalse(MnsEvent::is(['source' => '']));
+        $this->assertFalse(MnsEvent::is([]));
+    }
+
+    public function test_message_id_resolution()
+    {
+        $this->assertSame($this->mockedMessageId, $this->mockedEvent->messageId());
+    }
+
+    public function test_message_body_resolution()
+    {
+        $this->assertSame($this->mockedMessageBody, $this->mockedEvent->messageBody());
+    }
+
+    public function test_request_id_resolution()
+    {
+        $this->assertSame($this->mockedRequestId, $this->mockedEvent->requestId());
+    }
+}

--- a/tests/QueueMnsHandlerTest.php
+++ b/tests/QueueMnsHandlerTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Dew\Core\Tests;
+
+use Dew\Core\EventManager;
+use Dew\Core\Queue\MnsEvent;
+use Dew\Core\Queue\MnsHandler;
+use Dew\Core\Queue\MnsJob;
+use Dew\Core\Queue\MnsWorker;
+use Dew\Core\Tests\Stubs\StubHttpServer;
+use Dew\MnsDriver\MnsQueue;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Queue\NullQueue;
+use Illuminate\Queue\WorkerOptions;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use stdClass;
+
+class QueueMnsHandlerTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    protected string $connectionName;
+
+    protected string $queueName;
+
+    protected Container $mockedContainer;
+
+    protected Application $mockedLaravel;
+
+    protected MnsWorker $mockedWorker;
+
+    protected MnsQueue $mockedQueue;
+
+    protected MnsHandler $handler;
+
+    protected string $mockedMessageId;
+
+    protected array $mockedPayload;
+
+    protected MnsEvent $mockedEvent;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->connectionName = 'mns';
+        $this->queueName = 'default';
+
+        $this->mockedContainer = Mockery::mock(Container::class);
+
+        $this->mockedQueue = Mockery::mock(MnsQueue::class);
+        $this->mockedQueue->allows()->getMns();
+        $this->mockedQueue->allows()->getConnectionName()->andReturns($this->connectionName);
+        $this->mockedQueue->allows()->getQueue()->andReturns($this->queueName);
+
+        $this->mockedLaravel = Mockery::mock(Application::class);
+        $this->mockedLaravel->allows()->make(Container::class)->andReturns($this->mockedContainer);
+        $this->mockedLaravel->allows()->make('queue')->andReturns(tap(Mockery::mock(stdClass::class), function ($mock) {
+            $mock->allows()->connection()->andReturns($this->mockedQueue);
+        }));
+
+        $this->mockedWorker = Mockery::mock(MnsWorker::class);
+
+        $this->handler = new MnsHandler(new EventManager(new StubHttpServer));
+        $this->handler->laravelUsing($this->mockedLaravel);
+        $this->handler->workerUsing($this->mockedWorker);
+
+        $this->mockedMessageId = '4D309C5EAEC97F852A1C2C40FCF32EA7';
+        $this->mockedPayload = ['data' => ['foo' => 'bar']];
+        $this->mockedEvent = new MnsEvent(['data' => ['messageId' => $this->mockedMessageId, 'messageBody' => $this->mockedPayload]]);
+    }
+
+    public function test_mns_job_creation_from_event()
+    {
+        $job = $this->handler->toJob($this->mockedEvent, $this->mockedQueue);
+
+        $this->assertSame($this->mockedMessageId, $job->getJobId());
+        $this->assertSame(json_encode($this->mockedPayload), $job->getRawBody());
+        $this->assertSame($this->mockedPayload, $job->payload());
+        $this->assertSame($this->connectionName, $job->getConnectionName());
+        $this->assertSame($this->queueName, $job->getQueue());
+        $this->assertSame($job->attempts(), 1);
+    }
+
+    public function test_response_is_empty()
+    {
+        $this->mockedWorker->expects()->runMnsJob(Mockery::type(MnsJob::class), $this->connectionName, Mockery::type(WorkerOptions::class));
+        $response = $this->handler->handle($this->mockedEvent);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('', $response->getBody()->getContents());
+    }
+
+    public function test_queue_connection_must_be_a_mns_queue()
+    {
+        $mockedLaravel = Mockery::mock(Application::class);
+        $mockedLaravel->expects()->make('queue')->andReturns(tap(Mockery::mock(stdClass::class), function ($mock) {
+            $mock->expects()->connection()->andReturns(new NullQueue);
+        }));
+        $handler = new MnsHandler(new EventManager(new StubHttpServer));
+        $handler->laravelUsing($mockedLaravel);
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The queue must be a MNS queue.');
+        $handler->handle($this->mockedEvent);
+    }
+}

--- a/tests/QueueMnsJobTest.php
+++ b/tests/QueueMnsJobTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Dew\Core\Tests;
+
+use Dew\Core\Queue\MnsEvent;
+use Dew\Core\Queue\MnsJob;
+use Illuminate\Container\Container;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+class QueueMnsJobTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    protected string $connectionName;
+
+    protected string $queueName;
+
+    protected Container $mockedContainer;
+
+    protected stdClass $mockedMns;
+
+    protected string $mockedJob;
+
+    protected array $mockedData;
+
+    protected array $mockedPayload;
+
+    protected string $mockedRequestId;
+
+    protected string $mockedMessageId;
+
+    protected MnsEvent $mockedEvent;
+
+    protected int $mockedAttempted;
+
+    protected MnsEvent $mockedAttemptedEvent;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->connectionName = 'mns';
+        $this->queueName = 'default';
+
+        $this->mockedContainer = Mockery::mock(Container::class);
+        $this->mockedMns = Mockery::mock(stdClass::class);
+
+        $this->mockedJob = 'greeting';
+        $this->mockedData = ['greeting' => 'Hello world!'];
+        $this->mockedPayload = ['job' => $this->mockedJob, 'data' => $this->mockedData];
+        $this->mockedRequestId = '654C78B8384138799B6F5ED9';
+        $this->mockedMessageId = '4D309C5EAEC97F852A1C2C40FCF32EA7';
+
+        $this->mockedEvent = new MnsEvent([
+            'source' => 'dew.queue',
+            'data' => [
+                'requestId' => $this->mockedRequestId,
+                'messageId' => $this->mockedMessageId,
+                'messageBody' => $this->mockedPayload,
+            ],
+        ]);
+
+        $this->mockedAttempted = 1;
+        $this->mockedAttemptedEvent = new MnsEvent([
+            'source' => 'dew.queue',
+            'data' => [
+                'requestId' => $this->mockedRequestId,
+                'messageId' => $this->mockedMessageId,
+                'messageBody' => [...$this->mockedPayload, 'attempts' => $this->mockedAttempted],
+            ],
+        ]);
+    }
+
+    public function test_release_sends_job_onto_queue()
+    {
+        $this->mockedMns->expects()->sendMessage($this->queueName, ['MessageBody' => json_encode($this->mockedPayload + ['attempts' => 1]), 'DelaySeconds' => 60]);
+        $job = new MnsJob($this->mockedContainer, $this->mockedMns, $this->mockedEvent, $this->connectionName, $this->queueName);
+        $job->release(60);
+    }
+
+    public function test_attempts_resolution()
+    {
+        $job = new MnsJob($this->mockedContainer, $this->mockedMns, $this->mockedAttemptedEvent, $this->connectionName, $this->queueName);
+        $this->assertSame($this->mockedAttempted + 1, $job->attempts());
+    }
+
+    public function test_attempts_resolution_default()
+    {
+        $job = new MnsJob($this->mockedContainer, $this->mockedMns, $this->mockedEvent, $this->connectionName, $this->queueName);
+        $this->assertSame(1, $job->attempts());
+    }
+
+    public function test_fire_calls_handler()
+    {
+        $job = new MnsJob($this->mockedContainer, $this->mockedMns, $this->mockedEvent, $this->connectionName, $this->queueName);
+        $job->getContainer()->expects()->make($this->mockedJob)->andReturns($handler = Mockery::mock(stdClass::class));
+        $handler->expects()->fire($job, $this->mockedData);
+        $job->fire();
+    }
+}


### PR DESCRIPTION
The queue is one of the core components of the Laravel application. The PR adds an MNS queue handler to process the messages(jobs) sent from Eventbridge and configure the MNS connection on the fly with the Function Compute runtime context so that the application can communicate with ACS MNS services smoothly.