### PR TITLE
Define Dew cache store

### DIFF
--- a/src/Contracts/ProvidesDewContext.php
+++ b/src/Contracts/ProvidesDewContext.php
@@ -17,5 +17,5 @@ interface ProvidesDewContext
     /**
      * The cache table name on Tablestore instance.
      */
-    public function tablestoreCache(): string
+    public function tablestoreCache(): string;
 }

--- a/src/Contracts/ProvidesDewContext.php
+++ b/src/Contracts/ProvidesDewContext.php
@@ -8,4 +8,14 @@ interface ProvidesDewContext
      * The MNS queue name.
      */
     public function mnsQueue(): ?string;
+
+    /**
+     * The Tablestore instance name.
+     */
+    public function tablestoreInstance(): ?string;
+
+    /**
+     * The cache table name on Tablestore instance.
+     */
+    public function tablestoreCache(): string
 }

--- a/src/FunctionCompute.php
+++ b/src/FunctionCompute.php
@@ -142,6 +142,22 @@ class FunctionCompute implements ProvidesContext, ProvidesDewContext
     }
 
     /**
+     * The Tablestore instance name.
+     */
+    public function tablestoreInstance(): ?string
+    {
+        return $this->context['DEW_TABLESTORE_INSTNACE'] ?? null;
+    }
+
+    /**
+     * The cache table name on Tablestore instance.
+     */
+    public function tablestoreCache(): string
+    {
+        return $this->context['DEW_TABLESTORE_CACHE'] ?? 'cache';
+    }
+
+    /**
      * Make ACS config based on environment.
      */
     public function newConfig(): Config

--- a/src/FunctionCompute.php
+++ b/src/FunctionCompute.php
@@ -146,7 +146,7 @@ class FunctionCompute implements ProvidesContext, ProvidesDewContext
      */
     public function tablestoreInstance(): ?string
     {
-        return $this->context['DEW_TABLESTORE_INSTNACE'] ?? null;
+        return $this->context['DEW_TABLESTORE_INSTANCE'] ?? null;
     }
 
     /**

--- a/src/Support/DewCoreServiceProvider.php
+++ b/src/Support/DewCoreServiceProvider.php
@@ -19,6 +19,7 @@ class DewCoreServiceProvider extends ServiceProvider
             $this->ensureSessionFileLocationExists();
             $this->ensureCompiledViewPathExists();
             $this->configureQueueConnection($context);
+            $this->configureCacheStore($context);
         }
     }
 
@@ -61,6 +62,24 @@ class DewCoreServiceProvider extends ServiceProvider
                 $context->accountId(), $context->region()
             ),
             'queue' => $context->mnsQueue(),
+        ];
+    }
+
+    /**
+     * Configure Tablestore cache with the given runtime context.
+     */
+    protected function configureCacheStore(FunctionCompute $context): void
+    {
+        $this->app['config']['cache.stores.dew'] = [
+            'driver' => 'tablestore',
+            'key' => $context->accessKeyId(),
+            'secret' => $context->accessKeySecret(),
+            'token' => $context->securityToken(),
+            'endpoint' => sprintf('http://dew-%s.%s.vpc.ots.aliyuncs.com',
+                $context->tablestoreInstance(), $context->region()
+            ),
+            'instance' => $context->tablestoreInstance(),
+            'table' => $context->tablestoreCache(),
         ];
     }
 }


### PR DESCRIPTION
The cache store is dedicated to applications deployed and running in the Dew serverless environment.