### PR TITLE
Update `roadrunner-http` package to 3.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "spiral/roadrunner-http": "^3.0",
+        "spiral/roadrunner-http": "^3.5",
         "nyholm/psr7": "^1.8",
         "symfony/process": "^6.3",
         "hollodotme/fast-cgi-client": "^3.1",


### PR DESCRIPTION
The _roadrunner_ binary included in the PHP build is _2024.2.1_, which requires the composer package to be at least [v3.5](https://docs.roadrunner.dev/docs/general/compatibility#compatibility-with-roadrunner-php-packages).